### PR TITLE
Add googlels and googlebatch to nfcore_custom.config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,8 @@ jobs:
           - "genouest"
           - "gis"
           - "google"
+          - "googlebatch"
+          - "googlels"
           - "hasta"
           - "hebbe"
           - "hki"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Currently documentation is available for the following systems:
 - [GENOUEST](docs/genouest.md)
 - [GIS](docs/gis.md)
 - [GOOGLE](docs/google.md)
+- [GOOGLEBATCH](docs/googlebatch.md)
+- [GOOGLELS](docs/googlels.md)
 - [HASTA](docs/hasta.md)
 - [HEBBE](docs/hebbe.md)
 - [HKI](docs/hki.md)

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -45,6 +45,8 @@ profiles {
   genouest     { includeConfig "${params.custom_config_base}/conf/genouest.config" }
   gis          { includeConfig "${params.custom_config_base}/conf/gis.config" }
   google       { includeConfig "${params.custom_config_base}/conf/google.config" }
+  googlebatch  { includeConfig "${params.custom_config_base}/conf/googlebatch.config" }
+  googlels     { includeConfig "${params.custom_config_base}/conf/googlels.config" }
   hasta        { includeConfig "${params.custom_config_base}/conf/hasta.config" }
   hebbe        { includeConfig "${params.custom_config_base}/conf/hebbe.config" }
   hki          { includeConfig "${params.custom_config_base}/conf/hki.config"}


### PR DESCRIPTION
Just need to add a couple of markdown docs for `googlels` and `googlebatch` like in the example PR and should be good to go to add to nf-core/configs after testing.
https://github.com/nf-core/configs/pull/472